### PR TITLE
Query RelayHub for recipient balance

### DIFF
--- a/lib/components/RecipientForm.jsx
+++ b/lib/components/RecipientForm.jsx
@@ -30,7 +30,7 @@ const RecipientBalance = withFormProps(
 
       startSubscription() {
         if (this.subscription) { return }
-        if (this.props.relayHubAddress)) {
+        if (this.props.relayHubAddress) {
           this.subscription = this.props.client.subscribe({
             query: relayHubTargetSubscription,
             variables: {

--- a/lib/components/RecipientForm.jsx
+++ b/lib/components/RecipientForm.jsx
@@ -28,10 +28,6 @@ const RecipientBalance = withFormProps(
         this.startSubscription()
       }
 
-      componentDidUpdate () {
-        this.startSubscription()
-      }
-
       startSubscription() {
         if (this.subscription) { return }
         if (this.props.relayHubAddress)) {
@@ -88,10 +84,6 @@ export const RecipientForm = withFormProps(
     }
 
     componentDidMount () {
-      this.startSubscription()
-    }
-
-    componentDidUpdate () {
       this.startSubscription()
     }
 

--- a/lib/components/RecipientForm.jsx
+++ b/lib/components/RecipientForm.jsx
@@ -24,6 +24,35 @@ const RecipientBalance = withFormProps(
       }
     })
     (class _RecipientBalance extends PureComponent {
+      componentDidMount () {
+        this.startSubscription()
+      }
+
+      componentDidUpdate () {
+        this.startSubscription()
+      }
+
+      startSubscription() {
+        if (this.subscription) { return }
+        if (this.props.relayHubAddress)) {
+          this.subscription = this.props.client.subscribe({
+            query: relayHubTargetSubscription,
+            variables: {
+              relayHubAddress: this.props.relayHubAddress,
+              targetAddress: this.props.recipientAddress
+            }
+          }).subscribe(() => {
+            this.props.recipientBalanceQuery.refetch()
+          })
+        }
+      }
+
+      componentWillUnmount () {
+        if (this.subscription) {
+          this.subscription.unsubscribe()
+        }
+      }
+
       render() {
         const { RelayHub } = this.props.recipientBalanceQuery;
         if (RelayHub === undefined) {

--- a/lib/components/RecipientForm.jsx
+++ b/lib/components/RecipientForm.jsx
@@ -8,10 +8,33 @@ import { EthTextSymbol } from 'lib/components/EthTextSymbol'
 import { ConnectWallet } from 'lib/components/ConnectWallet'
 import { ErrorMsg } from 'lib/components/ErrorMsg'
 import { recipientQuery } from '../queries/recipientQuery'
+import { recipientBalanceQuery } from '../queries/recipientBalanceQuery'
 import { withFormProps } from 'lib/components/hoc/withFormProps'
 import { withNetworkAccountQuery } from './hoc/withNetworkAccountQuery'
 import { relayHubTargetSubscription } from '../subscriptions/relayHubTargetSubscription'
 import { RecipientDepositForm } from './RecipientDepositForm';
+
+const RecipientBalance = withFormProps(
+  withNetworkAccountQuery(
+    graphql(recipientBalanceQuery, {
+      name: 'recipientBalanceQuery',
+      options: (props) => {
+        const { recipientAddress, relayHubAddress } = props;
+        return { recipientAddress, relayHubAddress };
+      }
+    })
+    (class _RecipientBalance extends PureComponent {
+      render() {
+        const { RelayHub } = this.props.recipientBalanceQuery;
+        if (RelayHub === undefined) {
+          return ["..."];
+        } else {
+          return [ethers.utils.formatEther(RelayHub.balance)];
+        }
+      }
+    })
+  )
+);
 
 export const RecipientForm = withFormProps(
   withNetworkAccountQuery(
@@ -107,7 +130,7 @@ export const RecipientForm = withFormProps(
 
           <dl>
             <dt>Ether Balance </dt>
-            <dd>{balance ? ethers.utils.formatEther(balance) : '?'} <EthTextSymbol /></dd>
+            <dd><RecipientBalance relayHubAddress={relayHubAddress} recipientAddress={recipientAddress} /> <EthTextSymbol /></dd>
           </dl>
 
           {!ethereumPermission && (

--- a/lib/components/RecipientForm.jsx
+++ b/lib/components/RecipientForm.jsx
@@ -116,7 +116,7 @@ export const RecipientForm = withFormProps(
       } else if (loading) {
         return '...'
       } else {
-        const { balance, relayHubAddress } = RelayRecipient || {}
+        const { relayHubAddress } = RelayRecipient || {}
         let depositers
         if (this.state.currentTab === 1) {
           depositers = <RecipientDepositers relayHubAddress={relayHubAddress} recipientAddress={recipientAddress} />

--- a/lib/queries/recipientBalanceQuery.js
+++ b/lib/queries/recipientBalanceQuery.js
@@ -1,0 +1,9 @@
+import gql from 'graphql-tag'
+
+export const recipientBalanceQuery = gql`
+  query recipientBalanceQuery($recipientAddress: String!, $relayHubAddress: String!) {
+    RelayHub @contract(address: $relayHubAddress) {
+      balance: balanceOf(address: $recipientAddress)
+    }
+  }
+`

--- a/lib/queries/recipientQuery.js
+++ b/lib/queries/recipientQuery.js
@@ -4,7 +4,6 @@ export const recipientQuery = gql`
   query recipientQuery($address: String!) {
     RelayRecipient @contract(address: $address) {
       relayHubAddress: getHubAddr
-      balance: getRecipientBalance
     }
   }
 `


### PR DESCRIPTION
Fixes the following issue that is part of #1:

> the dapp tool assumes that the recipient implements a `getRecipientBalance` method, which may not always be the case.

I implemented this using the GraphQL stuff that is available in the project.